### PR TITLE
Ajout d'un Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.project
+.idea
 private/conf/conf.json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 ## Introduction
 
+## Vagrant
+
+https://docs.vagrantup.com/v2/
+
+```
+apt-get install ansible vagrant virtualbox
+```
+
+```
+vagrant up
+```
+
+Puis aller sur : *http://10.73.0.50/api.php/layers/commissariats?y=47.71969&x=-2.92285* pour tester. 
+Vous pouvez aussi essayer avec 127.0.0.1:8080
+
+```
+curl "http://10.73.0.50/api.php/layers/commissariats?y=47.71969&x=-2.92285"
+{"distkm":"7","service":"Brigade de proximit\u00e9 de Grand-Champ","tel":"+33 2 97 66 77 03"}
+```
+
 ## Pré-requis
 
 *   PostgreSQL > 9.2

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ apt-get install ansible vagrant virtualbox
 
 ```
 vagrant up
+vagrant ssh
 ```
 
 Puis aller sur : *http://10.73.0.50/api.php/layers/commissariats?y=47.71969&x=-2.92285* pour tester. 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "chef/debian-8.0"
+  config.vm.network :forwarded_port, guest: 80, host: 8080
+  config.vm.network :private_network, ip: "10.73.0.50"
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "ansible/playbook.yml"
+  end
+end

--- a/ansible/files/000-default.conf
+++ b/ansible/files/000-default.conf
@@ -1,0 +1,6 @@
+<VirtualHost *:80>
+        ServerAdmin webmaster@localhost
+        DocumentRoot /var/www/vagrant
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/ansible/files/conf.json
+++ b/ansible/files/conf.json
@@ -1,0 +1,12 @@
+{
+  "db": {
+    "driver" : "pgsql",
+    "host" : "localhost",
+    "dbname" : "db_dev",
+    "login" : "login",
+    "pwd" : "password"
+  },
+  "debug" : 1,
+  "api_version" : "0.1",
+  "env" : "dev"
+}

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,76 @@
+---
+- hosts: all
+  user: vagrant
+  sudo: yes
+
+  vars_files:
+    - vars.yml
+
+  tasks:
+    - name: install PostGis
+      apt: pkg={{ item }} update_cache=yes state=latest
+      with_items:
+        - postgresql-contrib-9.4
+        - postgresql-9.4-postgis-2.1
+        - postgresql-9.4-postgis-2.1-scripts
+        - python-psycopg2
+
+    - name: ensure postgis_template database exists
+      sudo_user: postgres
+      postgresql_db: db={{ db_name }} state=present
+
+    - name: add access
+      sudo_user: postgres
+      postgresql_user: db={{ db_name }} name={{ db_user }} password={{ db_password }} priv=ALL
+
+    - name: ensure postgis_template database exists
+      sudo_user: postgres
+      postgresql_db: db={{ db_name }} state=present owner={{ db_user }}
+
+    - name: run the postgis SQL scripts
+      sudo_user: postgres
+      command: psql -d {{ db_name }} -f {{ item }}
+      with_items:
+        - /usr/share/postgresql/9.4/contrib/postgis-2.1/postgis.sql
+        - /usr/share/postgresql/9.4/contrib/postgis-2.1/spatial_ref_sys.sql
+        - /usr/share/postgresql/9.4/contrib/postgis-2.1/postgis_comments.sql
+
+    - name: import db
+      sudo_user: postgres
+      shell: cd /tmp; cp /vagrant/private/install/georef_sql.tar.zip .; tar -xvf georef_sql.tar.zip; PGPASSWORD={{ db_password }} psql -h 127.0.0.1 -U {{ db_user }} -w {{ db_name }} < export_georef.sql
+
+    - name: set public priv. for {{ db_user }}
+      sudo_user: postgres
+      postgresql_privs: db={{ db_name }} privs=ALL type=schema objs=public role={{ db_user }}
+
+    - name: install Apache/PHP
+      apt: pkg={{ item }} update_cache=yes state=latest
+      with_items:
+        - php5-common
+        - libapache2-mod-php5
+        - php5-cli
+        - php5-pgsql
+
+    - name: link /vagrant to /var/www/vagrant
+      file: src=/vagrant/ dest=/var/www/vagrant state=link
+
+    - name: push Apache config
+      copy: src=files/000-default.conf dest=/etc/apache2/sites-enabled/
+      notify:
+        - restart apache2
+
+    - name: push api conf
+      copy: src=files/conf.json dest=/var/www/vagrant/private/conf/conf.json
+
+    - name: install composer
+      shell: cd /usr/local/bin; curl -sS https://getcomposer.org/installer | php; mv composer.phar composer
+
+    - name : composer install
+      composer: working_dir=/var/www/vagrant/libs
+
+  handlers:
+    - name: restart apache2
+      service: name=apache2 state=restarted
+
+    - name: restart postgresql
+      action: service name=postgresql state=restarted

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -1,0 +1,3 @@
+db_name: "db_dev"
+db_user: "login"
+db_password: "password"

--- a/libs/vendor/composer/autoload_classmap.php
+++ b/libs/vendor/composer/autoload_classmap.php
@@ -6,4 +6,25 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
+    'Slim\\Environment' => $vendorDir . '/slim/slim/Slim/Environment.php',
+    'Slim\\Exception\\Pass' => $vendorDir . '/slim/slim/Slim/Exception/Pass.php',
+    'Slim\\Exception\\Stop' => $vendorDir . '/slim/slim/Slim/Exception/Stop.php',
+    'Slim\\Helper\\Set' => $vendorDir . '/slim/slim/Slim/Helper/Set.php',
+    'Slim\\Http\\Cookies' => $vendorDir . '/slim/slim/Slim/Http/Cookies.php',
+    'Slim\\Http\\Headers' => $vendorDir . '/slim/slim/Slim/Http/Headers.php',
+    'Slim\\Http\\Request' => $vendorDir . '/slim/slim/Slim/Http/Request.php',
+    'Slim\\Http\\Response' => $vendorDir . '/slim/slim/Slim/Http/Response.php',
+    'Slim\\Http\\Util' => $vendorDir . '/slim/slim/Slim/Http/Util.php',
+    'Slim\\Log' => $vendorDir . '/slim/slim/Slim/Log.php',
+    'Slim\\LogWriter' => $vendorDir . '/slim/slim/Slim/LogWriter.php',
+    'Slim\\Middleware' => $vendorDir . '/slim/slim/Slim/Middleware.php',
+    'Slim\\Middleware\\ContentTypes' => $vendorDir . '/slim/slim/Slim/Middleware/ContentTypes.php',
+    'Slim\\Middleware\\Flash' => $vendorDir . '/slim/slim/Slim/Middleware/Flash.php',
+    'Slim\\Middleware\\MethodOverride' => $vendorDir . '/slim/slim/Slim/Middleware/MethodOverride.php',
+    'Slim\\Middleware\\PrettyExceptions' => $vendorDir . '/slim/slim/Slim/Middleware/PrettyExceptions.php',
+    'Slim\\Middleware\\SessionCookie' => $vendorDir . '/slim/slim/Slim/Middleware/SessionCookie.php',
+    'Slim\\Route' => $vendorDir . '/slim/slim/Slim/Route.php',
+    'Slim\\Router' => $vendorDir . '/slim/slim/Slim/Router.php',
+    'Slim\\Slim' => $vendorDir . '/slim/slim/Slim/Slim.php',
+    'Slim\\View' => $vendorDir . '/slim/slim/Slim/View.php',
 );


### PR DESCRIPTION
Dans le projet, faire un "vagrant up" pour lancer et initialiser une instance georef-api. Aller sur http://10.73.0.50/api.php/layers/commissariats?y=47.71969&x=-2.92285 ou http://127.0.0.1:8080/api.php/layers/commissariats?y=47.71969&x=-2.92285 pour tester la VM et l'API. 

Vous avez besoin de vagrant, virtualbox et ansible. Ansible permet de provisionner la VM (installation de postgis, apache, php ...) Vous pouvez éditer le _api.php_ et tester directement dans la vm sans refaire de provision car le / du projet est mappé sur le /var/www de l'Apache de la VM de dev.

Enfin, le playbook Ansible fait office de doc d'installation ;)

Bon code !
